### PR TITLE
Removing misleading info on Contracts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,43 +222,6 @@ FAQ
 
 .. code-block::
 
-  $ cat example.nim
-  import contracts
-  from math import sqrt, floor
-  proc isqrt[T: SomeInteger](x: T): T {.contractual.} =
-    require:
-      x >= 0
-    ensure:
-      result * result <= x
-      (result+1) * (result+1) > x
-    body:
-      (T)(x.toBiggestFloat().sqrt().floor().toBiggestInt())
-  echo isqrt(18)
-  echo isqrt(-8)
-
-  $ nim js -r example.nim
-  Error: undeclared identifier: 'deepCopy'
-
-  $ nim e example.nim
-  Error: undeclared identifier: 'deepCopy'
-
-  $ cat example2compiletime.nim
-  import contracts
-  from math import sqrt, floor
-  proc isqrt[T: SomeInteger](x: T): T {.contractual, compiletime.} =
-    require:
-      x >= 0
-    ensure:
-      result * result <= x
-      (result+1) * (result+1) > x
-    body:
-      (T)(x.toBiggestFloat().sqrt().floor().toBiggestInt())
-  echo isqrt(18)
-  echo isqrt(-8)
-
-  $ nim c -r example2compiletime.nim
-  Error: request to generate code for .compileTime proc: isqrt
-
   $ cloc ~/.nimble/pkgs/contracts-0.1.0/
   Language          files         blank        comment        code
   ----------------------------------------------------------------


### PR DESCRIPTION
Both examples of Contracts errors to be removed from README:
* the {.compiletime.} example was buggy to begin with. The error came from not using "static" when calling compile-time-only proc, which will always raise the same error in any Nim code, Contracts, Contra or just a plain proc. Contracts itself handles {.compiletime.} just fine and has been tested to do so.
* the JS and NimScript target examples have been solved successfully, they do not error with the newest versions of Contracts (even though NimScript cannot support all of Contracts' other features)